### PR TITLE
feat: optional bot control and geo match rules (TEF-576)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,23 @@ variable "environment" {
   default     = "development"
 }
 
+variable "geo_match_rules" {
+  type = map(object({
+    name          = optional(string, null)
+    action        = optional(string, "count")
+    priority      = optional(number, null)
+    country_codes = list(string)
+    negate        = optional(bool, false)
+  }))
+  description = "Geographic match rules for the WAF."
+  default     = {}
+
+  validation {
+    condition     = alltrue([for r in values(var.geo_match_rules) : contains(["allow", "block", "count"], r.action)])
+    error_message = "Each action must be \"allow\", \"block\", or \"count\"."
+  }
+}
+
 variable "hosted_zone_id" {
   type        = string
   description = "ID of the hosted zone for the domain, leave empty to have this module look it up."

--- a/variables.tf
+++ b/variables.tf
@@ -86,6 +86,21 @@ variable "origin_domain" {
   default     = null
 }
 
+variable "bot_control" {
+  type = object({
+    enable           = optional(bool, false)
+    inspection_level = optional(string, "COMMON")
+    priority         = optional(number, 700)
+  })
+  description = "Bot Control managed rule group configuration."
+  default     = {}
+
+  validation {
+    condition     = contains(["COMMON", "TARGETED"], var.bot_control.inspection_level)
+    error_message = "inspection_level must be either \"COMMON\" or \"TARGETED\"."
+  }
+}
+
 variable "passive" {
   type        = bool
   description = <<-EOT

--- a/waf.tf
+++ b/waf.tf
@@ -345,6 +345,46 @@ resource "aws_wafv2_web_acl" "waf" {
     }
   }
 
+  dynamic "rule" {
+    for_each = var.bot_control.enable ? [true] : []
+
+    content {
+      name     = "AWS-AWSManagedRulesBotControlRuleSet"
+      priority = var.bot_control.priority
+
+      override_action {
+        dynamic "none" {
+          for_each = var.passive ? [] : [true]
+          content {}
+        }
+
+        dynamic "count" {
+          for_each = var.passive ? [true] : []
+          content {}
+        }
+      }
+
+      statement {
+        managed_rule_group_statement {
+          name        = "AWSManagedRulesBotControlRuleSet"
+          vendor_name = "AWS"
+
+          managed_rule_group_configs {
+            aws_managed_rules_bot_control_rule_set {
+              inspection_level = var.bot_control.inspection_level
+            }
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${local.prefix}-waf-bot-control"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
   visibility_config {
     cloudwatch_metrics_enabled = true
     metric_name                = "${local.prefix}-waf"

--- a/waf.tf
+++ b/waf.tf
@@ -63,6 +63,57 @@ resource "aws_wafv2_web_acl" "waf" {
     }
   }
 
+  dynamic "rule" {
+    for_each = var.geo_match_rules
+    content {
+      name     = coalesce(rule.value.name, join("-", [local.prefix, "geo", rule.key]))
+      priority = rule.value.priority != null ? rule.value.priority : index(keys(var.geo_match_rules), rule.key) + length(var.ip_set_rules) + 1
+
+      action {
+        dynamic "allow" {
+          for_each = rule.value.action == "allow" ? [true] : []
+          content {}
+        }
+
+        dynamic "block" {
+          for_each = rule.value.action == "block" && !var.passive ? [true] : []
+          content {}
+        }
+
+        dynamic "count" {
+          for_each = rule.value.action == "count" || (rule.value.action == "block" && var.passive) ? [true] : []
+          content {}
+        }
+      }
+
+      statement {
+        dynamic "not_statement" {
+          for_each = rule.value.negate ? [true] : []
+          content {
+            statement {
+              geo_match_statement {
+                country_codes = rule.value.country_codes
+              }
+            }
+          }
+        }
+
+        dynamic "geo_match_statement" {
+          for_each = rule.value.negate ? [] : [true]
+          content {
+            country_codes = rule.value.country_codes
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${local.prefix}-waf-geo-${rule.key}"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
   # Attach the webhooks rule group to the WAF, if one was created.
   dynamic "rule" {
     for_each = length(var.webhooks) > 0 ? [true] : []

--- a/waf.tf
+++ b/waf.tf
@@ -63,57 +63,6 @@ resource "aws_wafv2_web_acl" "waf" {
     }
   }
 
-  dynamic "rule" {
-    for_each = var.geo_match_rules
-    content {
-      name     = coalesce(rule.value.name, join("-", [local.prefix, "geo", rule.key]))
-      priority = rule.value.priority != null ? rule.value.priority : index(keys(var.geo_match_rules), rule.key) + length(var.ip_set_rules) + 1
-
-      action {
-        dynamic "allow" {
-          for_each = rule.value.action == "allow" ? [true] : []
-          content {}
-        }
-
-        dynamic "block" {
-          for_each = rule.value.action == "block" && !var.passive ? [true] : []
-          content {}
-        }
-
-        dynamic "count" {
-          for_each = rule.value.action == "count" || (rule.value.action == "block" && var.passive) ? [true] : []
-          content {}
-        }
-      }
-
-      statement {
-        dynamic "not_statement" {
-          for_each = rule.value.negate ? [true] : []
-          content {
-            statement {
-              geo_match_statement {
-                country_codes = rule.value.country_codes
-              }
-            }
-          }
-        }
-
-        dynamic "geo_match_statement" {
-          for_each = rule.value.negate ? [] : [true]
-          content {
-            country_codes = rule.value.country_codes
-          }
-        }
-      }
-
-      visibility_config {
-        cloudwatch_metrics_enabled = true
-        metric_name                = "${local.prefix}-waf-geo-${rule.key}"
-        sampled_requests_enabled   = true
-      }
-    }
-  }
-
   # Attach the webhooks rule group to the WAF, if one was created.
   dynamic "rule" {
     for_each = length(var.webhooks) > 0 ? [true] : []
@@ -184,6 +133,57 @@ resource "aws_wafv2_web_acl" "waf" {
       visibility_config {
         cloudwatch_metrics_enabled = true
         metric_name                = "${local.prefix}-waf-rate-${rule.key}"
+        sampled_requests_enabled   = true
+      }
+    }
+  }
+
+  dynamic "rule" {
+    for_each = var.geo_match_rules
+    content {
+      name     = coalesce(rule.value.name, join("-", [local.prefix, "geo", rule.key]))
+      priority = rule.value.priority != null ? rule.value.priority : index(keys(var.geo_match_rules), rule.key) +  length(var.rate_limit_rules) + length(var.ip_set_rules) + 1
+
+      action {
+        dynamic "allow" {
+          for_each = rule.value.action == "allow" ? [true] : []
+          content {}
+        }
+
+        dynamic "block" {
+          for_each = rule.value.action == "block" && !var.passive ? [true] : []
+          content {}
+        }
+
+        dynamic "count" {
+          for_each = rule.value.action == "count" || (rule.value.action == "block" && var.passive) ? [true] : []
+          content {}
+        }
+      }
+
+      statement {
+        dynamic "not_statement" {
+          for_each = rule.value.negate ? [true] : []
+          content {
+            statement {
+              geo_match_statement {
+                country_codes = rule.value.country_codes
+              }
+            }
+          }
+        }
+
+        dynamic "geo_match_statement" {
+          for_each = rule.value.negate ? [] : [true]
+          content {
+            country_codes = rule.value.country_codes
+          }
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = true
+        metric_name                = "${local.prefix}-waf-geo-${rule.key}"
         sampled_requests_enabled   = true
       }
     }


### PR DESCRIPTION
This PR adds optional variables and corresponding WAF rules so that clients can opt in to using the `AWSManagedRulesBotControlRuleSet` at either `COMMON` or `TARGETED` protection level, and can opt in to geographic match rules and count, allow, or block traffic from certain countries.

I tried to set sensible defaults and am very new to this area and very open to feedback on it!