### PR TITLE
feat: Add support for path-based redirects via ordered cache behaviors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres
 to [Semantic Versioning][semver].
 
+## 2.3.0 (2026-07-01)
+
+### Feat
+
+- Support path-based redirects via ordered cache behaviors.
+
 ## 2.2.0 (2026-04-28)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][changelog], and this project adheres
 to [Semantic Versioning][semver].
 
-## 2.3.0 (2026-07-01)
+## 2.4.0 (2026-07-01)
 
 ### Feat
 
 - Support path-based redirects via ordered cache behaviors.
+
+## 2.3.0 (2026-07-01)
+
+### Feat
+
+- Add optional Bot Control managed rule set. (#47)
 
 ## 2.2.0 (2026-04-28)
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ webhooks_priority = 100
 | [ip_set_rules]         | Custom IP Set rules for the WAF                                                                                                                                                                                     | `map(object)`  | `{}`              | no          |
 | redacted_headers       | Headers to redact from logs. Keys are the header names, and values are the action to take. Valid actions are `"HASH"` and `"SUBSTITUTION"`.                                                                         | `map(string)`  | `{sane defaults}` | no          |
 | [rate_limit_rules]     | Rate limiting configuration for the WAF.                                                                                                                                                                            | `map(object)`  | `{}`              | no          |
+| [redirect_paths]       | Ordered cache behaviors for path-based redirects. Each entry attaches a CloudFront function that performs the redirect for requests matching the given path pattern.                                                 | `list(object)` | `[]`              | no          |
 | origin_domain          | Optional custom origin domain to point to. Defaults to `origin.subdomain.domain`. Only used if `use_custom_origin` is set to `true`.                                                                                | `string`       | n/a               | no          |
 | passive                | Enable passive mode for the WAF, counting all requests rather than blocking.                                                                                                                                        | `bool`         | `false`           | no          |
 | request_policy         | Managed request policy to associate with the distribution. See the [managed policies][managed-policies] for valid values.                                                                                           | `string`       | `"AllViewer"`     | no          |
@@ -282,6 +283,41 @@ module "cloudfront_waf" {
 | limit    | The number of requests allowed within the window. Minimum value of 10.                  | `number` | `10`      | no       |
 | priority | Rule priority. Defaults to the rule's position in the map + the number of IP set rules. | `number` | `null`    | no       |
 | window   | Number of seconds to limit requests in. Options are: 60, 120, 300, 600                  | `number` | `60`      | no       |
+
+### redirect_paths
+
+To redirect traffic from a specific path to another URL, you can specify a list
+of path-based redirect behaviors. Each entry creates an [ordered cache
+behavior][ordered-behaviors] that fires a CloudFront function before the request
+reaches the origin.
+
+> [!TIP]
+> Use the [`tofu-modules-aws-cloudfront-redirect`][cloudfront-redirect] module
+> with `create_distribution = false` to create the CloudFront function, then
+> pass the `function_arn` output here.
+
+```hcl
+module "cloudfront_waf" {
+  source = "github.com/codeforamerica/tofu-modules-aws-cloudfront-waf?ref=2.3.0"
+
+  project     = "my-project"
+  environment = "staging"
+  domain      = "my-project.org"
+  log_bucket  = module.logging.bucket
+
+  redirect_paths = [
+    {
+      path_pattern = "/old-path*"
+      function_arn = module.redirect.function_arn
+    }
+  ]
+}
+```
+
+| Name         | Description                                                                    | Type     | Default | Required |
+| ------------ | ------------------------------------------------------------------------------ | -------- | ------- | -------- |
+| path_pattern | CloudFront path pattern to match (e.g. `/old-path*`).                          | `string` | n/a     | yes      |
+| function_arn | ARN of the CloudFront function to fire on `viewer-request` for matching paths. | `string` | n/a     | yes      |
 
 ### upload_paths
 
@@ -423,7 +459,10 @@ will be allowed through.
 [ip_set_rules]: #ip_set_rules
 [latest-release]: https://github.com/codeforamerica/tofu-modules-aws-cloudfront-waf/releases/latest
 [managed-policies]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-origin-request-policies.html
+[cloudfront-redirect]: https://github.com/codeforamerica/tofu-modules-aws-cloudfront-redirect
+[ordered-behaviors]: https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/distribution-web-values-specify.html#DownloadDistValuesPathPattern
 [rate_limit_rules]: #rate_limit_rules
+[redirect_paths]: #redirect_paths
 [route53]: https://aws.amazon.com/route53/
 [rules-common]: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-crs
 [rules-inputs]: https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups-baseline.html#aws-managed-rule-groups-baseline-known-bad-inputs

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,27 @@ resource "aws_cloudfront_distribution" "waf" {
     viewer_protocol_policy = "redirect-to-https"
   }
 
+  dynamic "ordered_cache_behavior" {
+    for_each = var.redirect_paths
+
+    content {
+      path_pattern           = ordered_cache_behavior.value.path_pattern
+      allowed_methods        = ["GET", "HEAD"]
+      cached_methods         = ["GET", "HEAD"]
+      target_origin_id       = local.origin_domain
+      viewer_protocol_policy = "redirect-to-https"
+      min_ttl                = 0
+      default_ttl            = 0
+      max_ttl                = 0
+      cache_policy_id        = data.aws_cloudfront_cache_policy.policy.id
+
+      function_association {
+        event_type   = "viewer-request"
+        function_arn = ordered_cache_behavior.value.function_arn
+      }
+    }
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"

--- a/variables.tf
+++ b/variables.tf
@@ -209,6 +209,19 @@ variable "use_custom_origin" {
   default     = false
 }
 
+variable "redirect_paths" {
+  type = list(object({
+    path_pattern = string
+    function_arn = string
+  }))
+  description = <<-EOT
+    Ordered cache behaviors for path-based redirects. Each entry attaches a
+    CloudFront function that performs the redirect for requests matching the
+    given path pattern.
+    EOT
+  default     = []
+}
+
 variable "webhooks" {
   type = map(object({
     paths = list(object({


### PR DESCRIPTION
Adds a `redirect_paths` variable that creates ordered cache behaviors on the
CloudFront distribution, firing a CloudFront function on `viewer-request` for
matching paths. Intended to be used with `tofu-modules-aws-cloudfront-redirect`
using `create_distribution = false`.